### PR TITLE
Allowing configuration of cookie attributes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,14 @@ pub struct AxumSessionConfig {
     pub(crate) cookie_path: String,
     /// Session ID character length
     pub(crate) cookie_len: usize,
+    /// Session cookie max age None means the browser deletes cookie on close
+    pub(crate) cookie_max_age: Option<Duration>,
+    /// Session cookie http only flag
+    pub(crate) cookie_http_only: bool,
+    /// Session cookie secure flag
+    pub(crate) cookie_secure: bool,
+    /// Session cookie domain
+    pub(crate) cookie_domain: Option<String>,
     /// Session Database table name default is async_sessions
     pub(crate) table_name: String,
     /// Session Database Max Poll Connections. Can not be 0
@@ -47,6 +55,40 @@ impl AxumSessionConfig {
     #[must_use]
     pub fn with_memory_lifetime(mut self, time: Duration) -> Self {
         self.memory_lifespan = time;
+        self
+    }
+
+    /// Set session cookie max_age (expiration time) in browser.
+    ///
+    #[must_use]
+    pub fn with_max_age(mut self, time: Option<Duration>) -> Self {
+        self.cookie_max_age = time;
+        self
+    }
+
+    /// Set session cookie http_only flag.
+    /// If set javascript has no access to the cookie.
+    ///
+    #[must_use]
+    pub fn with_http_only(mut self, is_set: bool) -> Self {
+        self.cookie_http_only = is_set;
+        self
+    }
+
+    /// Set session cookie secure flag.
+    /// If set the cookie will only be sent over https.
+    ///
+    #[must_use]
+    pub fn with_secure(mut self, is_set: bool) -> Self {
+        self.cookie_secure = is_set;
+        self
+    }
+
+    /// Set session cookie domain name
+    ///
+    #[must_use]
+    pub fn with_cookie_domain(mut self, name: Option<String>) -> Self {
+        self.cookie_domain = name;
         self
     }
 
@@ -95,6 +137,10 @@ impl Default for AxumSessionConfig {
             cookie_name: "sqlx_session".into(),
             cookie_path: "/".into(),
             cookie_len: 16,
+            cookie_max_age: None,
+            cookie_http_only: true,
+            cookie_secure: false,
+            cookie_domain: None,
             table_name: "async_sessions".into(),
             max_connections: 5,
             /// Unload memory after 60mins if it has not been accessed.


### PR DESCRIPTION
Partly implementing Issue #4
Session can be configured by 
http_only is on by default

```
let session_config = AxumSessionConfig::default()
        .with_table_name("session")
        .with_cookie_name("a")
        .with_max_age(Some(chrono::Duration::minutes(15)))
        .with_secure(false)
        ;
```