### PR TITLE
Don't panic on missing key

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -42,13 +42,13 @@ impl AxumSession {
     ) -> Option<T> {
         let store_rg = self.store.inner.read().await;
 
-        let mut instance = store_rg
-            .get(&self.id.0.to_string())
-            .expect("Session data unexpectedly missing")
-            .lock()
-            .await;
-
-        func(&mut instance)
+        if let Some(v) = store_rg.get(&self.id.0.to_string()) {
+            let mut instance = v.lock().await;
+            func(&mut instance)
+        } else {
+            tracing::warn!("Session data unexpectedly missing");
+            None
+        }
     }
 
     ///Sets the Entire Session to be Cleaned on next load.


### PR DESCRIPTION
This fix a panic in AxumSession.

I haven't really tested this yet, but I got this error on a service I'm running that uses AxumSession. This is one is solution, I don't know if it is the right one :)

Was about to add some tests for this as well, but I can send another patch with that later if you want.