### PR TITLE
Added `new` associated function to AxumSessionConfig.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -100,6 +100,12 @@ impl std::fmt::Debug for AxumSessionConfig {
 }
 
 impl AxumSessionConfig {
+    /// Creates [`Default`] configuration of [`AxumSessionConfig`].
+    /// This is equivalent to the [`AxumSessionConfig::default()`].
+    #[must_use]
+    pub fn new() -> Self {
+        Default::default()
+    }
     /// Sets the sessions database pool's max connection's limit.
     ///
     /// # Examples


### PR DESCRIPTION
People expect that any struct has this associated function. This is the traditional method in Rust.