### PR TITLE
remove double quote from column in mysql

### DIFF
--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -24,9 +24,9 @@ impl AxumDatabasePool for AxumMySqlPool {
         sqlx::query(
             &r#"
             CREATE TABLE IF NOT EXISTS %%TABLE_NAME%% (
-                "id" VARCHAR(128) NOT NULL PRIMARY KEY,
-                "expires" INTEGER NULL,
-                "session" TEXT NOT NULL
+                id VARCHAR(128) NOT NULL PRIMARY KEY,
+                expires INTEGER NULL,
+                session TEXT NOT NULL
             )
         "#
             .replace("%%TABLE_NAME%%", table_name),


### PR DESCRIPTION
Mysql does not support double quoting column names like postgresql does.
When using mysql client in my service I get the following error:
```
Sqlx(Database(MySqlDatabaseError { code: Some("42000"), number: 1064, message: "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '\"id\" VARCHAR(128) NOT NULL PRIMARY KEY,\n                \"expires\" INTEGER NUL...' at line 2" }))
```