### PR TITLE
add Debug and Clone derive to AxumNullPool

### DIFF
--- a/src/databases/null.rs
+++ b/src/databases/null.rs
@@ -6,6 +6,7 @@ pub type AxumNullSessionStore = AxumSessionStore<AxumNullPool>;
 
 /// Null Pool type for AxumDatabasePool.
 /// Use this when you do not want to load any database.
+#[derive(Debug, Clone)]
 pub struct AxumNullPool;
 
 #[async_trait]


### PR DESCRIPTION
In the examples, it is shown that we can use AxumNullPool to avoid using DB (useful for unit tests). But based on the docs/source code AxumSessionStore requires that the client `T: AxumDatabasePool + Clone + Debug + Sync + Send + 'static`
The issue is that AxumNullPool is neither Clone nor Debug. So example with AxumNullPool actually does not work, I also tried it in on my own. There is no reason for AxumNullPool not to be Clone and or Debug

This is simple fix by adding derive with Clone  and Debug