### PR TITLE
Allow SameSite attribute to be set independently of Domain attribute

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -52,8 +52,7 @@ pub struct AxumSessionConfig {
     pub(crate) cookie_name: Cow<'static, str>,
     /// Session cookie path
     pub(crate) cookie_path: Cow<'static, str>,
-    /// Resticts how Cookies are sent cross-site. Default is `SameSite::None`
-    /// Only works if domain is also set.
+    /// Resticts how Cookies are sent cross-site. Default is `SameSite::Lax`
     pub(crate) cookie_same_site: SameSite,
     /// Session cookie secure flag
     pub(crate) cookie_secure: bool,
@@ -422,7 +421,7 @@ impl Default for AxumSessionConfig {
             cookie_http_only: true,
             cookie_secure: false,
             cookie_domain: None,
-            cookie_same_site: SameSite::None,
+            cookie_same_site: SameSite::Lax,
             storable_cookie_name: "session_acceptance".into(),
             storable_cookie_max_age: Some(Duration::days(100)),
             table_name: "async_sessions".into(),

--- a/src/service.rs
+++ b/src/service.rs
@@ -247,12 +247,12 @@ fn create_cookie<'a>(
     let mut cookie_builder = Cookie::build(cookie_type.get_name(config), value)
         .path(config.cookie_path.clone())
         .secure(config.cookie_secure)
-        .http_only(config.cookie_http_only);
+        .http_only(config.cookie_http_only)
+        .same_site(config.cookie_same_site);
 
     if let Some(domain) = &config.cookie_domain {
         cookie_builder = cookie_builder
-            .domain(domain.clone())
-            .same_site(config.cookie_same_site);
+            .domain(domain.clone());
     }
 
     if let Some(max_age) = cookie_type.get_age(config) {


### PR DESCRIPTION
Domain attribute and SameSite attributes are independent of each other. Domain attribute defines the host to which the cookie will be sent. SameSite attribute allows servers to assert that a cookie ought not to be sent along with cross-site requests. SameSite attribute should be configurable independently of Domain attribute.

https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.3

According to the specification, if server sends set-cookie header without SameSite attribute,
SameSite's default value is "Lax" (previously this was "None". It seems changed.).

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite

### Note
This is breaking changes.