### PR TITLE
Fix the table delete syntax for sqlite

### DIFF
--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -126,7 +126,7 @@ impl DatabasePool for SessionSqlitePool {
     }
 
     async fn delete_all(&self, table_name: &str) -> Result<(), SessionError> {
-        sqlx::query(&r#"TRUNCATE %%TABLE_NAME%%"#.replace("%%TABLE_NAME%%", table_name))
+        sqlx::query(&r#"DELETE FROM %%TABLE_NAME%%"#.replace("%%TABLE_NAME%%", table_name))
             .execute(&self.pool)
             .await?;
         Ok(())


### PR DESCRIPTION
The current `delete_all` method for sqlite uses `TRUNCATE` which causes `clear_store()` to fail:

```
Error: error returned from database: (code: 1) near "TRUNCATE": syntax error
Caused by:
    (code: 1) near "TRUNCATE": syntax error
```

This is just a small fix to change `TRUNCATE` over to `DELETE FROM` to achieve the same result ([sqlite docs reference](https://sqlite.org/lang_delete.html)). It seems to work for me so far, but I'm not sure if there's anything else I should be looking out for.

Thanks for the crate!