### PR TITLE
Disable chrono default features. Fix RUSTSEC-2020-0071.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ fdb_tag = []
 axum-core = {version = "0.3.4"}
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.95"
-chrono = { version = "0.4.24", features = ["clock", "serde", "std"] }
+chrono = { version = "0.4.24", default-features = false, features = ["clock", "serde", "std"] }
 tokio = { version = "1.27.0", features = ["full"] }
 async-trait = "0.1.68"
 tracing = "0.1.37"


### PR DESCRIPTION
This should remove the complaint about RUSTSEC-2020-0071 being caused by the axum_session library. It may still appear due to the usage of default features in surrealdb lib, if surrealdb feature is enabled in this lib. I've also suggested they do this.

I ran `cargo fmt` and it added a newline to this as well.